### PR TITLE
Permit version overriding

### DIFF
--- a/contracts/test/ERC20PermitOverride.sol
+++ b/contracts/test/ERC20PermitOverride.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.6.0;
 import "../token/ERC20Permit.sol";
 
 contract ERC20PermitOverride is ERC20Permit {
-    constructor(string memory name_, string memory symbol_) internal ERC20Permit(name_, symbol_) { }
+    constructor(string memory name_, string memory symbol_) public ERC20Permit(name_, symbol_) { }
 
     function version() public pure override returns(string memory) { return "2"; }
 }

--- a/contracts/test/ERC20PermitOverride.sol
+++ b/contracts/test/ERC20PermitOverride.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.6.0;
+
+
+import "../token/ERC20Permit.sol";
+
+contract ERC20PermitOverride is ERC20Permit {
+    constructor(string memory name_, string memory symbol_) internal ERC20Permit(name_, symbol_) { }
+
+    function version() public pure override returns(string memory) { return "2"; }
+}

--- a/contracts/token/ERC20Permit.sol
+++ b/contracts/token/ERC20Permit.sol
@@ -29,12 +29,15 @@ abstract contract ERC20Permit is ERC20, IERC2612 {
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes(name_)),
-                keccak256(bytes("1")),
+                keccak256(bytes(version())),
                 chainId,
                 address(this)
             )
         );
     }
+
+    /// @dev Setting the version as a function so that it can be overriden
+    function version() public pure virtual returns(string memory) { return "1"; }
 
     /**
      * @dev See {IERC2612-permit}.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yield-protocol/utils",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Solidity contracts used for Yield projects that can be reused",
   "author": "Yield Inc.",
   "files": [

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -39,7 +39,7 @@ export function getSignatureDigest(
   signatureCount: BigNumberish,
   deadline: BigNumberish
 ) {
-  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, chainId)
+  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, '1', chainId)
   return keccak256(
     solidityPack(
       ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
@@ -63,6 +63,7 @@ export function getSignatureDigest(
 export function getPermitDigest(
   name: string,
   address: string,
+  version: string,
   chainId: number,
   approve: {
     owner: string
@@ -72,7 +73,7 @@ export function getPermitDigest(
   nonce: BigNumberish,
   deadline: BigNumberish
 ) {
-  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, chainId)
+  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, version, chainId)
   return keccak256(
     solidityPack(
       ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
@@ -103,7 +104,7 @@ export function getDaiDigest(
   nonce: BigNumberish,
   deadline: BigNumberish
 ) {
-  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, chainId)
+  const DOMAIN_SEPARATOR = getDomainSeparator(name, address, '1', chainId)
   return keccak256(
     solidityPack(
       ['bytes1', 'bytes1', 'bytes32', 'bytes32'],
@@ -123,14 +124,14 @@ export function getDaiDigest(
 }
 
 // Gets the EIP712 domain separator
-export function getDomainSeparator(name: string, contractAddress: string, chainId: number) {
+export function getDomainSeparator(name: string, contractAddress: string, version: string, chainId: number) {
   return keccak256(
     defaultAbiCoder.encode(
       ['bytes32', 'bytes32', 'bytes32', 'uint256', 'address'],
       [
         keccak256(toUtf8Bytes('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)')),
         keccak256(toUtf8Bytes(name)),
-        keccak256(toUtf8Bytes('1')),
+        keccak256(toUtf8Bytes(version)),
         chainId,
         contractAddress,
       ]

--- a/test/041_erc20Permit.ts
+++ b/test/041_erc20Permit.ts
@@ -46,6 +46,11 @@ describe('ERC20Permit', () => {
   it('overrides version', async () => {
     expect(
       await erc20Override.DOMAIN_SEPARATOR()
+    ).to.be.equal(
+      getDomainSeparator(await erc20Override.name(), erc20Override.address, await erc20Override.version(), chainId)
+    )
+    expect(
+      await erc20Override.DOMAIN_SEPARATOR()
     ).to.be.not.equal(
       getDomainSeparator(await erc20Override.name(), erc20Override.address, await erc20.version(), chainId)
     )

--- a/test/041_erc20Permit.ts
+++ b/test/041_erc20Permit.ts
@@ -34,24 +34,25 @@ describe('ERC20Permit', () => {
     erc20 = (await deployContract(deployerAcc, ERC20PermitArtifact, [])) as ERC20Permit
     erc20FromOther = erc20.connect(otherAcc)
 
-    erc20Override = (await deployContract(deployerAcc, ERC20PermitOverrideArtifact, ["Override", "OVR"])) as ERC20PermitOverride
+    erc20Override = (await deployContract(deployerAcc, ERC20PermitOverrideArtifact, [
+      'Override',
+      'OVR',
+    ])) as ERC20PermitOverride
   })
 
   it('initializes DOMAIN_SEPARATOR and PERMIT_TYPEHASH correctly', async () => {
     expect(await erc20.PERMIT_TYPEHASH()).to.be.equal(PERMIT_TYPEHASH)
 
-    expect(await erc20.DOMAIN_SEPARATOR()).to.be.equal(getDomainSeparator(await erc20.name(), erc20.address, await erc20.version(), chainId))
+    expect(await erc20.DOMAIN_SEPARATOR()).to.be.equal(
+      getDomainSeparator(await erc20.name(), erc20.address, await erc20.version(), chainId)
+    )
   })
 
   it('overrides version', async () => {
-    expect(
-      await erc20Override.DOMAIN_SEPARATOR()
-    ).to.be.equal(
+    expect(await erc20Override.DOMAIN_SEPARATOR()).to.be.equal(
       getDomainSeparator(await erc20Override.name(), erc20Override.address, await erc20Override.version(), chainId)
     )
-    expect(
-      await erc20Override.DOMAIN_SEPARATOR()
-    ).to.be.not.equal(
+    expect(await erc20Override.DOMAIN_SEPARATOR()).to.be.not.equal(
       getDomainSeparator(await erc20Override.name(), erc20Override.address, await erc20.version(), chainId)
     )
   })
@@ -68,7 +69,15 @@ describe('ERC20Permit', () => {
     const nonce = await erc20.nonces(owner)
 
     // Get the EIP712 digest
-    const digest = getPermitDigest(await erc20.name(), erc20.address, await erc20.version(), chainId, approve, nonce, deadline)
+    const digest = getPermitDigest(
+      await erc20.name(),
+      erc20.address,
+      await erc20.version(),
+      chainId,
+      approve,
+      nonce,
+      deadline
+    )
 
     // Sign it
     const { v, r, s } = sign(digest, privateKey0)


### PR DESCRIPTION
Updated `ERC20Permit.sol` and `signatures.ts` so that ERC2612 tokens can update their version. There is an example as well.